### PR TITLE
fix: turn off no-underscore-dangle rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
       },
     ],
     '@typescript-eslint/dot-notation': 'error',
+    'no-underscore-dangle': 'off',
   },
   settings: {
     'import/parsers': {


### PR DESCRIPTION
## Description :clipboard:

Turn off rule "no-underscore-dangle". This setting interfered with working with hidden fields and getters/setters. In cases like this, there was a eslint error
```ts
class MyClass {
  protected _x: number; //Error
  // Some code
  get x() {
    return this._x;
  }
}

```

## Done / deadline :date:

12.05.2024 / 12.05.2024

## Comments (optional) :speech_balloon:

Perhaps this rule was part of the Airbnb standard and can be disabled in some other way